### PR TITLE
improve usage of ynh_add_systemd_config

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -117,7 +117,7 @@ ynh_script_progression --message="Configuring a systemd service..."
 
 # Create a dedicated systemd config
 start_file="$final_path/env/bin/$app"
-ynh_add_systemd_config --others_var="conf_file start_file"     # substitute __CONF_FILE__ by $conf_file
+ynh_add_systemd_config #--others_var="conf_file start_file"      substitute __CONF_FILE__ by $conf_file
 
 #=================================================
 # MODIFY A CONFIG FILE


### PR DESCRIPTION
## Problem

- the Bullseye CI is reporting an error : Invalid argument: --
--others_var is known to be deprecated and should be deleted. variables are replaced automatically.
## Solution
avoid deprecated agrument

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
