### PR TITLE
Fix broken status: add system and python dependencies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Play music, podcasts and radio programs from local disk and various streaming services",
         "fr": "Écouter de la musique, des podcasts et des programmes radio depuis le disque local et divers services de streaming"
     },
-    "version": "3.2.0~ynh2",
+    "version": "3.4.2~ynh1",
     "url": "https://www.mopidy.com",
     "upstream": {
         "license": "Apache-2.0",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,7 +8,7 @@
 pkg_dependencies="acl build-essential python3-dev python3-pip python3-venv git postgresql postgresql-contrib \
 gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly lsb-base \
 python3-gst-1.0 python3-tornado debconf python3-pkg-resources python3-pykka python3-requests \
-gstreamer1.0-alsa gstreamer1.0-pulseaudio gstreamer1.0-tools"
+gstreamer1.0-alsa gstreamer1.0-pulseaudio gstreamer1.0-tools libcairo2-dev libffi-dev libgirepository1.0-dev libglib2.0-dev"
 
 #=================================================
 # PERSONAL HELPERS
@@ -28,20 +28,22 @@ myynh_install() {
 	ynh_exec_as $app $final_path/env/bin/pip install --upgrade --no-cache-dir pip
 
 	# to make Gstreamer visible in Python environment
+ 	$final_path/env/bin/python3 -m pip install wheel
 	$final_path/env/bin/python3 -m pip install vext
 	$final_path/env/bin/python3 -m pip install --no-binary=:all: vext.gi
+ 	$final_path/env/bin/python3 -m pip install --ignore-installed --no-cache pygobject
 
 	# install essential packages
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy==$(ynh_app_upstream_version)
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-local==3.2.1
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-MusicBox-Webclient==3.1.0
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-YouTube==3.3
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir mopidy-ytmusic==0.3.0
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-RadioNet==0.2.2
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-Podcast==3.0.0
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-Podcast-iTunes==3.0.0
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-SoundCloud==3.0.1
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-MPD==3.1.0
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-local
+ 	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-MPD
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-MusicBox-Webclient
+#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-YouTube
+#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-YTMusic
+#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-RadioNet
+#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-Podcast
+#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-Podcast-iTunes
+#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-SoundCloud
 	)
 }
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -34,16 +34,16 @@ myynh_install() {
  	$final_path/env/bin/python3 -m pip install --ignore-installed --no-cache pygobject
 
 	# install essential packages
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-local
- 	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-MPD
-	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-MusicBox-Webclient
-#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-YouTube
-#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-YTMusic
-#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-RadioNet
-#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-Podcast
-#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-Podcast-iTunes
-#	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-SoundCloud
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy==$(ynh_app_upstream_version)
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-local==3.2.1
+ 	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-MPD==3.3.0
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-MusicBox-Webclient==3.1.0
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-YouTube==3.7
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-YTMusic==0.3.8
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-RadioNet==0.2.2
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-Podcast==3.0.1
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-Podcast-iTunes==3.0.1
+	ynh_exec_as $app $final_path/env/bin/python3 -m pip install --no-cache-dir Mopidy-SoundCloud==3.0.2
 	)
 }
 


### PR DESCRIPTION
## Problem

Python fails to install some libraries and extensions

## Solution

Solution inspired by:
https://mopidy.com/blog/2019/12/27/mopidy-3-faq/#so-how-do-i-install-mopidy-3-on-ubuntu-1804-lts

1. Packages needed by pygobject added to pkg_dependencies:
libcairo2-dev libffi-dev libgirepository1.0-dev libglib2.0-dev

2. Python libraries added:
vext needs **wheel**
some extensions need **pygobject**

3. By the way, updated to the latest versions of mopidy and its extensions.

Tested in VirtualBox environment, amd64, YunoHost 11.2.5 (stable)
The log : https://paste.yunohost.org/raw/apucuhigal

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
